### PR TITLE
tiny z-index fix

### DIFF
--- a/ui/Navigation.tsx
+++ b/ui/Navigation.tsx
@@ -6,7 +6,7 @@ import { AiOutlineTwitter, AiOutlineGithub } from "react-icons/ai"
 
 export const Navigation = () => {
   return (
-    <div className="sticky top-0 z-10 py-2 bg-white md:py-6 md:mb-6">
+    <div className="sticky top-0 z-20 py-2 bg-white md:py-6 md:mb-6">
       <div className="container px-4 mx-auto lg:max-w-4xl md:flex md:items-center md:justify-between">
         <Link href="/">
           <a


### PR DESCRIPTION
Video content on blog had a z-index of 10 as well, so it was going over the navigation. Super tiny fix.